### PR TITLE
fix(ci): run cymbal in single container to persist index

### DIFF
--- a/.github/workflows/cymbal-impact.yml
+++ b/.github/workflows/cymbal-impact.yml
@@ -25,52 +25,81 @@ jobs:
       - name: Pull cymbal image
         run: docker pull ghcr.io/1broseidon/cymbal@sha256:43f0bb34b73ac6580a0a2daaa6673d95ad28860dd4ff29f441515af3aedca607
 
-      - name: Analyse impact
-        id: analyse
+      - name: Detect changed files
+        id: detect
         run: |
-          cymbal() { docker run --rm -v "$PWD":/workspace ghcr.io/1broseidon/cymbal@sha256:43f0bb34b73ac6580a0a2daaa6673d95ad28860dd4ff29f441515af3aedca607 "$@"; }
-
           CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD -- '*.go')
           if [ -z "$CHANGED" ]; then
             echo "No Go files changed."
             echo '[]' > impact-report.json
-            echo "has_impact=false" >> "$GITHUB_OUTPUT"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "$CHANGED" > /tmp/changed-files.txt
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "Changed Go files:"
+          cat /tmp/changed-files.txt
 
-          # cymbal auto-indexes on first query — no explicit index step needed.
-          SYMBOLS=$(echo "$CHANGED" \
-            | tr '\n' '\0' \
-            | xargs -0 -I{} cymbal outline {} --json 2>/dev/null \
-            | jq -r '.symbols[]?.name' 2>/dev/null \
-            | sort -u)
+      - name: Run cymbal analysis
+        id: analyse
+        if: steps.detect.outputs.has_changes == 'true'
+        run: |
+          # Run all cymbal commands in a single container so the index persists.
+          docker run --rm \
+            -v "$PWD":/workspace \
+            -v /tmp/changed-files.txt:/tmp/changed-files.txt:ro \
+            --entrypoint /bin/sh \
+            ghcr.io/1broseidon/cymbal@sha256:43f0bb34b73ac6580a0a2daaa6673d95ad28860dd4ff29f441515af3aedca607 \
+            -c '
+              cd /workspace
 
-          if [ -z "$SYMBOLS" ]; then
-            echo "No symbols extracted from changed files."
-            echo '[]' > impact-report.json
-            echo "has_impact=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+              # Build index once
+              cymbal index . 2>&1 | tail -1
 
-          echo "### Changed symbols"
-          echo "$SYMBOLS"
-          echo ""
+              # Extract symbols from changed files
+              SYMBOLS=""
+              while IFS= read -r file; do
+                OUT=$(cymbal outline "$file" --json 2>/dev/null || true)
+                NAMES=$(echo "$OUT" | jq -r ".symbols[]?.name" 2>/dev/null || true)
+                if [ -n "$NAMES" ]; then
+                  SYMBOLS=$(printf "%s\n%s" "$SYMBOLS" "$NAMES")
+                fi
+              done < /tmp/changed-files.txt
 
-          echo "$SYMBOLS" | xargs -r cymbal impact --json 2>/dev/null \
-            | tee impact-report.json
+              SYMBOLS=$(echo "$SYMBOLS" | sort -u | sed "/^$/d")
 
-          # Ensure valid JSON; fall back to empty array if cymbal produced nothing.
-          if ! jq empty impact-report.json 2>/dev/null; then
-            echo '[]' > impact-report.json
-          fi
+              if [ -z "$SYMBOLS" ]; then
+                echo "No symbols extracted from changed files."
+                echo "[]" > impact-report.json
+                exit 0
+              fi
 
-          ENTRIES=$(jq 'if type == "array" then length else 0 end' impact-report.json 2>/dev/null || echo 0)
-          echo "### $ENTRIES impact entries"
+              echo "### Changed symbols"
+              echo "$SYMBOLS"
+              echo ""
 
-          if [ "$ENTRIES" -gt 0 ]; then
+              # Run impact analysis — pass all symbols at once
+              printf "%s\n" "$SYMBOLS" \
+                | xargs -r -n 200 cymbal impact --json 2>/dev/null \
+                | jq -s "map(select(type == \"array\")) | add // []" \
+                | tee impact-report.json || true
+
+              # Validate JSON output
+              if ! jq empty impact-report.json 2>/dev/null; then
+                echo "[]" > impact-report.json
+              fi
+
+              ENTRIES=$(jq "if type == \"array\" then length else 0 end" impact-report.json 2>/dev/null || echo 0)
+              echo "### $ENTRIES impact entries"
+            '
+
+          # Check if impact report has entries (for the comment step)
+          if [ -f impact-report.json ] && [ "$(jq 'if type == "array" then length else 0 end' impact-report.json 2>/dev/null || echo 0)" -gt 0 ]; then
             echo "has_impact=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_impact=false" >> "$GITHUB_OUTPUT"
+            # Ensure file exists for artifact upload
+            [ -f impact-report.json ] || echo '[]' > impact-report.json
           fi
 
       - name: Comment impact on PR
@@ -93,6 +122,7 @@ jobs:
           gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"
 
       - name: Upload impact report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cymbal-impact-report


### PR DESCRIPTION
## Summary

- Fixes cymbal impact analysis producing no output because each `cymbal outline` call spawned a separate Docker container, losing the index between invocations
- All cymbal commands (`index`, `outline`, `impact`) now run in a **single container** with one explicit index build
- Changed file list is bind-mounted into the container

## Test plan

- [ ] Verify the workflow produces symbol output on PR #2 (Dream Engine Phase 2)
- [ ] Check that `impact-report.json` artifact contains actual data
- [ ] Verify PR comment is posted when impact entries exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a two-step detect-and-analyze workflow to skip work when no relevant files changed
  * Consolidated indexing to a single long-lived analysis run, then analyze only changed files
  * Aggregated and deduplicated symbols and batched impact computation for efficiency
  * Normalized report output with a safe empty-array fallback and ensured a report file is always produced
  * Made artifact upload unconditional and improved overall error handling and reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->