### PR TITLE
feat(cognitive): hippocampal pattern separation

### DIFF
--- a/internal/cognitive/hippocampal.go
+++ b/internal/cognitive/hippocampal.go
@@ -12,6 +12,13 @@ type HippocampalConfig struct {
 
 	// Episode tuning knobs — only used when EnableEpisodes is true.
 	EpisodeConfig EpisodeConfig `json:"episode_config"`
+
+	// EnableSeparation activates hippocampal pattern separation.
+	// When true, cross-context ACTIVATE results are penalised using entity
+	// Jaccard similarity as a context mismatch signal.
+	EnableSeparation bool `json:"enable_separation"`
+
+	SeparationConfig SeparationConfig `json:"separation_config"`
 }
 
 // EpisodeConfig holds tuning parameters for the episode segmentation worker.
@@ -29,12 +36,27 @@ type EpisodeConfig struct {
 	AssociationWeight float32 `json:"association_weight"`
 }
 
+// SeparationConfig tunes the pattern separation scoring adjustment.
+type SeparationConfig struct {
+	// RepulsionAlpha is the maximum score penalty applied to cross-context
+	// candidates. A candidate with zero entity overlap receives a multiplier
+	// of (1.0 - RepulsionAlpha). Must be in [0, 1). Zero disables the penalty. Default: 0.3.
+	RepulsionAlpha float64
+
+	// ContextMismatchFn selects the method used to detect context mismatch.
+	// Currently only "entity" is supported: Jaccard similarity over the
+	// entity sets of the query and candidate engrams. Default: "entity".
+	ContextMismatchFn string
+}
+
 // DefaultHippocampalConfig returns a HippocampalConfig with all features
 // disabled and sane defaults for the tuning knobs.
 func DefaultHippocampalConfig() HippocampalConfig {
 	return HippocampalConfig{
-		EnableEpisodes: false,
-		EpisodeConfig:  DefaultEpisodeConfig(),
+		EnableEpisodes:   false,
+		EpisodeConfig:    DefaultEpisodeConfig(),
+		EnableSeparation: false,
+		SeparationConfig: DefaultSeparationConfig(),
 	}
 }
 
@@ -44,5 +66,13 @@ func DefaultEpisodeConfig() EpisodeConfig {
 		SimilarityThreshold: 0.5,
 		TimeGap:             30 * time.Minute,
 		AssociationWeight:   0.3,
+	}
+}
+
+// DefaultSeparationConfig returns conservative separation defaults.
+func DefaultSeparationConfig() SeparationConfig {
+	return SeparationConfig{
+		RepulsionAlpha:    0.3,
+		ContextMismatchFn: "entity",
 	}
 }

--- a/internal/cognitive/separation.go
+++ b/internal/cognitive/separation.go
@@ -1,0 +1,109 @@
+package cognitive
+
+import (
+	"context"
+)
+
+// SeparationStore abstracts entity lookups needed by the pattern separation scorer.
+// The storage.PebbleStore satisfies this interface via ScanEngramEntities.
+type SeparationStore interface {
+	// GetEngramEntities returns entity names linked to an engram.
+	GetEngramEntities(ctx context.Context, ws [8]byte, engramID [16]byte) ([]string, error)
+}
+
+// SeparationScorer applies hippocampal pattern separation to ACTIVATE results.
+// For each candidate, it computes entity Jaccard similarity against the query's
+// entity context and returns a score multiplier in [0.1, 1.0]. Candidates that
+// share no entity context with the query receive the maximum penalty.
+type SeparationScorer struct {
+	store  SeparationStore
+	config SeparationConfig
+}
+
+// NewSeparationScorer creates a scorer with the given store and config.
+func NewSeparationScorer(store SeparationStore, config SeparationConfig) *SeparationScorer {
+	return &SeparationScorer{
+		store:  store,
+		config: config,
+	}
+}
+
+// ScoreSeparation returns a multiplier [0.1, 1.0] for each candidate.
+// 1.0 = same context (no penalty), lower = different context (penalised).
+//
+// If queryEntities is empty, all candidates receive 1.0 (no penalty) because
+// there is no entity context to compare against.
+func (s *SeparationScorer) ScoreSeparation(ctx context.Context, ws [8]byte, queryEntities []string, candidateIDs [][16]byte) ([]float64, error) {
+	multipliers := make([]float64, len(candidateIDs))
+
+	// No query entities → no separation signal; return all 1.0.
+	if len(queryEntities) == 0 {
+		for i := range multipliers {
+			multipliers[i] = 1.0
+		}
+		return multipliers, nil
+	}
+
+	// Build a set from query entities for O(1) lookup.
+	querySet := make(map[string]struct{}, len(queryEntities))
+	for _, e := range queryEntities {
+		querySet[e] = struct{}{}
+	}
+
+	alpha := s.config.RepulsionAlpha
+	if alpha <= 0 || alpha >= 1 {
+		alpha = 0.3
+	}
+
+	for i, cid := range candidateIDs {
+		candEntities, err := s.store.GetEngramEntities(ctx, ws, cid)
+		if err != nil {
+			// On error, be lenient — no penalty.
+			multipliers[i] = 1.0
+			continue
+		}
+
+		jaccard := JaccardSimilarity(querySet, candEntities)
+		mult := 1.0 - alpha*(1.0-jaccard)
+
+		// Clamp to [0.1, 1.0].
+		if mult < 0.1 {
+			mult = 0.1
+		}
+		if mult > 1.0 {
+			mult = 1.0
+		}
+		multipliers[i] = mult
+	}
+
+	return multipliers, nil
+}
+
+// JaccardSimilarity computes |A ∩ B| / |A ∪ B| between a set A (map) and
+// a slice B. Returns 0.0 if both are empty, 1.0 if identical.
+func JaccardSimilarity(setA map[string]struct{}, sliceB []string) float64 {
+	if len(setA) == 0 && len(sliceB) == 0 {
+		return 0.0
+	}
+
+	setB := make(map[string]struct{}, len(sliceB))
+	for _, e := range sliceB {
+		setB[e] = struct{}{}
+	}
+
+	// |A ∩ B|
+	intersection := 0
+	for k := range setA {
+		if _, ok := setB[k]; ok {
+			intersection++
+		}
+	}
+
+	// |A ∪ B| = |A| + |B| - |A ∩ B|
+	union := len(setA) + len(setB) - intersection
+	if union == 0 {
+		return 0.0
+	}
+
+	return float64(intersection) / float64(union)
+}

--- a/internal/cognitive/separation.go
+++ b/internal/cognitive/separation.go
@@ -51,7 +51,7 @@ func (s *SeparationScorer) ScoreSeparation(ctx context.Context, ws [8]byte, quer
 	}
 
 	alpha := s.config.RepulsionAlpha
-	if alpha <= 0 || alpha >= 1 {
+	if alpha < 0 || alpha >= 1 {
 		alpha = 0.3
 	}
 

--- a/internal/cognitive/separation_test.go
+++ b/internal/cognitive/separation_test.go
@@ -1,0 +1,215 @@
+package cognitive
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+// mockSeparationStore is a test double that returns pre-configured entity lists.
+type mockSeparationStore struct {
+	entities map[[16]byte][]string
+}
+
+func (m *mockSeparationStore) GetEngramEntities(_ context.Context, _ [8]byte, engramID [16]byte) ([]string, error) {
+	return m.entities[engramID], nil
+}
+
+func id(n byte) [16]byte {
+	var b [16]byte
+	b[15] = n
+	return b
+}
+
+// TestJaccardSimilarity verifies the Jaccard math for various set configurations.
+func TestJaccardSimilarity(t *testing.T) {
+	tests := []struct {
+		name   string
+		setA   map[string]struct{}
+		sliceB []string
+		want   float64
+	}{
+		{
+			name:   "both empty",
+			setA:   map[string]struct{}{},
+			sliceB: nil,
+			want:   0.0,
+		},
+		{
+			name:   "identical sets",
+			setA:   map[string]struct{}{"auth": {}, "migration": {}},
+			sliceB: []string{"auth", "migration"},
+			want:   1.0,
+		},
+		{
+			name:   "no overlap",
+			setA:   map[string]struct{}{"auth": {}, "migration": {}},
+			sliceB: []string{"billing", "payment"},
+			want:   0.0,
+		},
+		{
+			name:   "partial overlap",
+			setA:   map[string]struct{}{"auth": {}, "migration": {}},
+			sliceB: []string{"auth", "billing"},
+			want:   1.0 / 3.0, // intersection=1 (auth), union=3 (auth,migration,billing)
+		},
+		{
+			name:   "A empty B non-empty",
+			setA:   map[string]struct{}{},
+			sliceB: []string{"auth"},
+			want:   0.0,
+		},
+		{
+			name:   "A non-empty B empty",
+			setA:   map[string]struct{}{"auth": {}},
+			sliceB: nil,
+			want:   0.0,
+		},
+		{
+			name:   "B has duplicates",
+			setA:   map[string]struct{}{"auth": {}, "migration": {}},
+			sliceB: []string{"auth", "auth", "migration"},
+			want:   1.0, // duplicates collapsed → identical sets
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := JaccardSimilarity(tt.setA, tt.sliceB)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("JaccardSimilarity = %f, want %f", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSeparationScoring verifies that cross-context candidates get penalised.
+func TestSeparationScoring(t *testing.T) {
+	store := &mockSeparationStore{
+		entities: map[[16]byte][]string{
+			id(1): {"auth", "migration"},       // same context as query
+			id(2): {"billing", "payment"},       // different context
+			id(3): {"auth", "billing"},           // partial overlap
+			id(4): {},                            // no entities at all
+		},
+	}
+
+	scorer := NewSeparationScorer(store, SeparationConfig{
+		RepulsionAlpha:    0.3,
+		ContextMismatchFn: "entity",
+	})
+
+	queryEntities := []string{"auth", "migration"}
+	candidates := [][16]byte{id(1), id(2), id(3), id(4)}
+	ws := [8]byte{}
+
+	mults, err := scorer.ScoreSeparation(context.Background(), ws, queryEntities, candidates)
+	if err != nil {
+		t.Fatalf("ScoreSeparation error: %v", err)
+	}
+
+	// id(1): jaccard=1.0, mult = 1.0 - 0.3*(1-1) = 1.0
+	if math.Abs(mults[0]-1.0) > 1e-9 {
+		t.Errorf("same context multiplier = %f, want 1.0", mults[0])
+	}
+
+	// id(2): jaccard=0.0, mult = 1.0 - 0.3*(1-0) = 0.7
+	if math.Abs(mults[1]-0.7) > 1e-9 {
+		t.Errorf("different context multiplier = %f, want 0.7", mults[1])
+	}
+
+	// id(3): jaccard = 1/3, mult = 1.0 - 0.3*(1-1/3) = 1.0 - 0.2 = 0.8
+	expected3 := 1.0 - 0.3*(1.0-1.0/3.0)
+	if math.Abs(mults[2]-expected3) > 1e-9 {
+		t.Errorf("partial overlap multiplier = %f, want %f", mults[2], expected3)
+	}
+
+	// id(4): jaccard=0.0 (empty candidate vs non-empty query), mult = 0.7
+	if math.Abs(mults[3]-0.7) > 1e-9 {
+		t.Errorf("no-entity candidate multiplier = %f, want 0.7", mults[3])
+	}
+}
+
+// TestSameContextNoPenalty verifies that candidates sharing exact entity context
+// with the query receive multiplier 1.0 (no penalty).
+func TestSameContextNoPenalty(t *testing.T) {
+	store := &mockSeparationStore{
+		entities: map[[16]byte][]string{
+			id(1): {"project-X", "auth", "kubernetes"},
+			id(2): {"project-X", "auth", "kubernetes"},
+		},
+	}
+
+	scorer := NewSeparationScorer(store, SeparationConfig{
+		RepulsionAlpha:    0.5, // aggressive alpha
+		ContextMismatchFn: "entity",
+	})
+
+	queryEntities := []string{"project-X", "auth", "kubernetes"}
+	candidates := [][16]byte{id(1), id(2)}
+	ws := [8]byte{}
+
+	mults, err := scorer.ScoreSeparation(context.Background(), ws, queryEntities, candidates)
+	if err != nil {
+		t.Fatalf("ScoreSeparation error: %v", err)
+	}
+
+	for i, m := range mults {
+		if math.Abs(m-1.0) > 1e-9 {
+			t.Errorf("candidate %d: multiplier = %f, want 1.0 (same context)", i, m)
+		}
+	}
+}
+
+// TestSeparationDisabled verifies that nil scorer is a no-op (caller must
+// check for nil before calling). This test documents the expected integration
+// pattern: when separation is disabled, the engine skips the scoring step.
+func TestSeparationDisabled(t *testing.T) {
+	// The integration contract is: if scorer == nil, skip separation.
+	// This test verifies that a scorer with empty query entities produces no penalty,
+	// which is the fallback behaviour when entity context is unavailable.
+	store := &mockSeparationStore{
+		entities: map[[16]byte][]string{
+			id(1): {"billing"},
+		},
+	}
+
+	scorer := NewSeparationScorer(store, DefaultSeparationConfig())
+
+	// Empty query entities → all multipliers should be 1.0.
+	mults, err := scorer.ScoreSeparation(context.Background(), [8]byte{}, nil, [][16]byte{id(1)})
+	if err != nil {
+		t.Fatalf("ScoreSeparation error: %v", err)
+	}
+	if len(mults) != 1 {
+		t.Fatalf("expected 1 multiplier, got %d", len(mults))
+	}
+	if math.Abs(mults[0]-1.0) > 1e-9 {
+		t.Errorf("empty query entities multiplier = %f, want 1.0", mults[0])
+	}
+}
+
+// TestSeparationClampFloor verifies the 0.1 floor clamp when alpha is extreme.
+func TestSeparationClampFloor(t *testing.T) {
+	store := &mockSeparationStore{
+		entities: map[[16]byte][]string{
+			id(1): {}, // no entities → jaccard=0.0
+		},
+	}
+
+	// Alpha out of valid range → defaults to 0.3.
+	scorer := NewSeparationScorer(store, SeparationConfig{
+		RepulsionAlpha:    1.5, // invalid → clamped to 0.3 by scorer
+		ContextMismatchFn: "entity",
+	})
+
+	mults, err := scorer.ScoreSeparation(context.Background(), [8]byte{}, []string{"auth"}, [][16]byte{id(1)})
+	if err != nil {
+		t.Fatalf("ScoreSeparation error: %v", err)
+	}
+
+	// With alpha defaulted to 0.3: mult = 1.0 - 0.3*1.0 = 0.7
+	if math.Abs(mults[0]-0.7) > 1e-9 {
+		t.Errorf("clamped alpha multiplier = %f, want 0.7", mults[0])
+	}
+}

--- a/internal/cognitive/separation_test.go
+++ b/internal/cognitive/separation_test.go
@@ -189,8 +189,8 @@ func TestSeparationDisabled(t *testing.T) {
 	}
 }
 
-// TestSeparationClampFloor verifies the 0.1 floor clamp when alpha is extreme.
-func TestSeparationClampFloor(t *testing.T) {
+// TestSeparationInvalidAlphaDefault verifies that out-of-range alpha defaults to 0.3.
+func TestSeparationInvalidAlphaDefault(t *testing.T) {
 	store := &mockSeparationStore{
 		entities: map[[16]byte][]string{
 			id(1): {}, // no entities → jaccard=0.0
@@ -211,5 +211,29 @@ func TestSeparationClampFloor(t *testing.T) {
 	// With alpha defaulted to 0.3: mult = 1.0 - 0.3*1.0 = 0.7
 	if math.Abs(mults[0]-0.7) > 1e-9 {
 		t.Errorf("clamped alpha multiplier = %f, want 0.7", mults[0])
+	}
+}
+
+// TestSeparationClampFloor verifies the 0.1 floor clamp with high alpha and zero overlap.
+func TestSeparationClampFloor(t *testing.T) {
+	store := &mockSeparationStore{
+		entities: map[[16]byte][]string{
+			id(1): {}, // no entities → jaccard=0.0
+		},
+	}
+
+	// alpha=0.99, jaccard=0.0 → raw mult = 1.0 - 0.99*(1.0-0.0) = 0.01, clamped to 0.1
+	scorer := NewSeparationScorer(store, SeparationConfig{
+		RepulsionAlpha:    0.99,
+		ContextMismatchFn: "entity",
+	})
+
+	mults, err := scorer.ScoreSeparation(context.Background(), [8]byte{}, []string{"auth"}, [][16]byte{id(1)})
+	if err != nil {
+		t.Fatalf("ScoreSeparation error: %v", err)
+	}
+
+	if math.Abs(mults[0]-0.1) > 1e-9 {
+		t.Errorf("floor clamp multiplier = %f, want 0.1", mults[0])
 	}
 }

--- a/internal/cognitive/store_adapters.go
+++ b/internal/cognitive/store_adapters.go
@@ -114,3 +114,22 @@ func (a *confidenceStoreAdapter) GetConfidence(ctx context.Context, ws [8]byte, 
 func (a *confidenceStoreAdapter) UpdateConfidence(ctx context.Context, ws [8]byte, id [16]byte, confidence float32) error {
 	return a.store.UpdateConfidence(ctx, ws, storage.ULID(id), confidence)
 }
+
+// separationStoreAdapter adapts storage.EngineStore to cognitive.SeparationStore.
+type separationStoreAdapter struct {
+	store storage.EngineStore
+}
+
+// NewSeparationStoreAdapter returns a SeparationStore backed by the given EngineStore.
+func NewSeparationStoreAdapter(store storage.EngineStore) SeparationStore {
+	return &separationStoreAdapter{store: store}
+}
+
+func (a *separationStoreAdapter) GetEngramEntities(ctx context.Context, ws [8]byte, engramID [16]byte) ([]string, error) {
+	var entities []string
+	err := a.store.ScanEngramEntities(ctx, ws, storage.ULID(engramID), func(name string) error {
+		entities = append(entities, name)
+		return nil
+	})
+	return entities, err
+}

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -24,4 +24,5 @@ type EngineConfig struct {
 	EpisodeWorker    *cognitive.EpisodeWorker                       // nil → no episode segmentation
 	Embedder         activation.Embedder                            // nil → no semantic search
 	HNSWRegistry     *hnsw.Registry                                 // nil → no HNSW indexes
+	HippocampalConfig *cognitive.HippocampalConfig                  // nil → hippocampal features disabled
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -210,7 +210,8 @@ type Engine struct {
 	vaultOpWG      sync.WaitGroup
 	vaultOpStopped atomic.Bool
 
-	hnswRegistry *hnsw.Registry // per-vault HNSW indexes (shared with activation)
+	hnswRegistry     *hnsw.Registry              // per-vault HNSW indexes (shared with activation)
+	separationScorer *cognitive.SeparationScorer // nil = hippocampal pattern separation disabled
 
 	// vaultMu provides per-vault mutual exclusion for destructive vault operations
 	// (PruneVault, ReindexFTSVault, ClearVault). Maps string vault name → *sync.Mutex.
@@ -351,6 +352,11 @@ func NewEngine(cfg EngineConfig) *Engine {
 		hnswRegistry:     cfg.HNSWRegistry,
 		jobManager:          vaultjob.NewManager(),
 		replayFailCounts:    make(map[storage.ULID]int),
+	}
+	// Wire hippocampal pattern separation if enabled.
+	if cfg.HippocampalConfig != nil && cfg.HippocampalConfig.EnableSeparation {
+		sepStore := cognitive.NewSeparationStoreAdapter(store)
+		e.separationScorer = cognitive.NewSeparationScorer(sepStore, cfg.HippocampalConfig.SeparationConfig)
 	}
 	// Start async novelty worker to decouple O(N) Jaccard scan from write hot path.
 	// engine:spawn-ok — tracked by noveltyDone channel, drained in Stop()
@@ -1939,6 +1945,12 @@ func (e *Engine) activateCore(ctx context.Context, req *mbp.ActivateRequest, str
 	if actReq.MaxResults > 0 && len(result.Activations) > actReq.MaxResults {
 		result.Activations = result.Activations[:actReq.MaxResults]
 	}
+
+	// Hippocampal pattern separation: penalise cross-context candidates.
+	// Uses entity Jaccard similarity between top-seed entities and each candidate
+	// to reduce interference from engrams that are semantically similar but belong
+	// to a different entity context (e.g. "auth migration" in project A vs B).
+	result.Activations = e.applySeparation(ctx, wsPrefix, result.Activations)
 
 	// Convert result.Activations to []mbp.ActivationItem
 	items := make([]mbp.ActivationItem, len(result.Activations))

--- a/internal/engine/engine_separation.go
+++ b/internal/engine/engine_separation.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	"github.com/scrypster/muninndb/internal/engine/activation"
-	"github.com/scrypster/muninndb/internal/storage"
 )
 
 const (
@@ -51,10 +50,22 @@ func (e *Engine) applySeparation(ctx context.Context, ws [8]byte, results []acti
 		return results
 	}
 
-	// Build candidate ID slice.
-	candidateIDs := make([][16]byte, len(results))
+	// Build seed ID set for filtering.
+	seedIDs := make(map[[16]byte]struct{}, seedCount)
+	for _, seed := range results[:seedCount] {
+		seedIDs[[16]byte(seed.Engram.ID)] = struct{}{}
+	}
+
+	// Build candidate ID slice, excluding seeds to avoid double entity lookup.
+	candidateIDs := make([][16]byte, 0, len(results)-seedCount)
+	candidateIdx := make([]int, 0, len(results)-seedCount) // maps back to results index
 	for i, r := range results {
-		candidateIDs[i] = [16]byte(r.Engram.ID)
+		rid := [16]byte(r.Engram.ID)
+		if _, isSeed := seedIDs[rid]; isSeed {
+			continue
+		}
+		candidateIDs = append(candidateIDs, rid)
+		candidateIdx = append(candidateIdx, i)
 	}
 
 	multipliers, err := e.separationScorer.ScoreSeparation(ctx, ws, queryEntities, candidateIDs)
@@ -63,18 +74,9 @@ func (e *Engine) applySeparation(ctx context.Context, ws [8]byte, results []acti
 		return results
 	}
 
-	// Apply multipliers. Skip seed results (first seedCount) — they define
-	// the query context and should not be penalised.
-	seedIDs := make(map[storage.ULID]struct{}, seedCount)
-	for _, seed := range results[:seedCount] {
-		seedIDs[seed.Engram.ID] = struct{}{}
-	}
-
-	for i := range results {
-		if _, isSeed := seedIDs[results[i].Engram.ID]; isSeed {
-			continue
-		}
-		results[i].Score *= multipliers[i]
+	// Apply multipliers only to non-seed candidates.
+	for j, ri := range candidateIdx {
+		results[ri].Score *= multipliers[j]
 	}
 
 	// Re-sort descending by score after separation adjustments.

--- a/internal/engine/engine_separation.go
+++ b/internal/engine/engine_separation.go
@@ -1,0 +1,86 @@
+package engine
+
+import (
+	"context"
+	"sort"
+
+	"github.com/scrypster/muninndb/internal/engine/activation"
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+const (
+	// separationSeedTopN is the number of top results whose entity links are
+	// used as the "query entity context" for pattern separation scoring.
+	// Matches entityBoostTopN so both features derive context from the same seeds.
+	separationSeedTopN = 5
+)
+
+// applySeparation applies hippocampal pattern separation to post-scored results.
+// It collects entities from the top-N seed results (the "query entity context"),
+// then penalises candidates whose entity sets have low Jaccard overlap with the
+// seeds. This reduces cross-context interference without modifying the HNSW index.
+//
+// No-op when e.separationScorer is nil (feature disabled).
+func (e *Engine) applySeparation(ctx context.Context, ws [8]byte, results []activation.ScoredEngram) []activation.ScoredEngram {
+	if e.separationScorer == nil || len(results) == 0 {
+		return results
+	}
+
+	// Collect entities from the top-N seed results to form the query entity context.
+	seedCount := len(results)
+	if seedCount > separationSeedTopN {
+		seedCount = separationSeedTopN
+	}
+
+	queryEntitySet := make(map[string]struct{})
+	for _, seed := range results[:seedCount] {
+		_ = e.store.ScanEngramEntities(ctx, ws, seed.Engram.ID, func(entityName string) error {
+			queryEntitySet[entityName] = struct{}{}
+			return nil
+		})
+	}
+
+	// Flatten the entity set to a slice for the scorer.
+	queryEntities := make([]string, 0, len(queryEntitySet))
+	for name := range queryEntitySet {
+		queryEntities = append(queryEntities, name)
+	}
+
+	// No entity context from seeds → no separation signal.
+	if len(queryEntities) == 0 {
+		return results
+	}
+
+	// Build candidate ID slice.
+	candidateIDs := make([][16]byte, len(results))
+	for i, r := range results {
+		candidateIDs[i] = [16]byte(r.Engram.ID)
+	}
+
+	multipliers, err := e.separationScorer.ScoreSeparation(ctx, ws, queryEntities, candidateIDs)
+	if err != nil {
+		// On error, return results unmodified.
+		return results
+	}
+
+	// Apply multipliers. Skip seed results (first seedCount) — they define
+	// the query context and should not be penalised.
+	seedIDs := make(map[storage.ULID]struct{}, seedCount)
+	for _, seed := range results[:seedCount] {
+		seedIDs[seed.Engram.ID] = struct{}{}
+	}
+
+	for i := range results {
+		if _, isSeed := seedIDs[results[i].Engram.ID]; isSeed {
+			continue
+		}
+		results[i].Score *= multipliers[i]
+	}
+
+	// Re-sort descending by score after separation adjustments.
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+
+	return results
+}


### PR DESCRIPTION
## Summary

Adds **pattern separation** — the hippocampal dentate gyrus creates maximally distinct representations for similar-but-different inputs, preventing cross-context confusion.

MuninnDB's HNSW index stores raw embeddings — two engrams about "auth migration" in different projects have near-identical vectors and compete in ACTIVATE. This PR adds a context-based scoring penalty that reduces cross-context interference without modifying HNSW internals.

### What's implemented
- **`SeparationConfig`** — feature flag + tuning (alpha, context mismatch method). Disabled by default.
- **`SeparationScorer`** — computes Jaccard similarity between query context entities and candidate entities. Cross-context results get a `1.0 - alpha * (1.0 - jaccard)` multiplier.
- **Engine integration** — applied as post-scoring multiplier in `activateCore()` after entity boost. Top-5 seed results define "query context" and are never penalized.
- **Comprehensive tests** — Jaccard math (7 subcases), cross-context penalty, same-context no-penalty, disabled no-op, floor clamping.

### Design decisions
- **Scoring layer, not index modification** — HNSW internals untouched. Separation is a pure multiplier applied after Phase 6.
- **Entity-based context** — uses entity co-occurrence as the context signal (most reliable signal already in the database).
- **Seed results define context** — top-5 activation results' entities become the reference context. This avoids needing to extract entities from the query string.
- **Clamped to [0.1, 1.0]** — never fully suppresses a result, only reduces its rank.

### Files changed (7 files, +484 lines)
| File | Change |
|------|--------|
| `internal/cognitive/hippocampal.go` | New: SeparationConfig + defaults |
| `internal/cognitive/separation.go` | New: SeparationScorer + Jaccard |
| `internal/cognitive/separation_test.go` | New: 5 test functions |
| `internal/cognitive/store_adapters.go` | New: SeparationStore adapter |
| `internal/engine/config.go` | Add HippocampalConfig to EngineConfig |
| `internal/engine/engine.go` | Wire separation scorer |
| `internal/engine/engine_separation.go` | New: applySeparation() method |

**Independent of PR #26** (episodes) — can be merged in any order.

Closes #17, closes #18

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All cognitive tests pass, zero regressions
- [ ] Integration test: write engrams with same topic but different entity sets, verify ACTIVATE ranks same-context results higher

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "pattern separation" ranking to de-emphasize results from different entity contexts and reduce redundancy.

* **Improvements**
  * Configurable separation behavior (strength and mismatch method) with safe defaults and disabled-by-default.
  * Separation is applied after initial ranking and preserves results if scoring fails.

* **Tests**
  * Unit tests covering similarity, scoring behavior, edge cases, and configuration bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->