### PR TITLE
feat(mcp): episode management tools

### DIFF
--- a/internal/engine/engine_episodes.go
+++ b/internal/engine/engine_episodes.go
@@ -22,6 +22,11 @@ type Episode struct {
 // It scans all forward associations in the vault, filters for RelSameEpisode,
 // builds connected components via union-find, and returns episodes sorted by
 // StartTime descending, limited to `limit`.
+//
+// Note: singleton episodes (single engrams with no same_episode associations)
+// are not included because they have no edges to discover. This is by design —
+// the EpisodeWorker only creates same_episode links between consecutive engrams
+// within an episode. A singleton means a boundary was detected immediately.
 func (e *Engine) ListEpisodes(ctx context.Context, vault string, limit int) ([]Episode, error) {
 	if limit <= 0 {
 		limit = 10
@@ -126,4 +131,76 @@ func (e *Engine) ListEpisodes(ctx context.Context, vault string, limit int) ([]E
 		episodes = episodes[:limit]
 	}
 	return episodes, nil
+}
+
+// GetEpisodeByMember walks same_episode associations from the given engram via BFS
+// and returns the connected episode. This avoids the limit imposed by ListEpisodes,
+// making it suitable for direct lookups by episode ID (the first engram's ULID).
+func (e *Engine) GetEpisodeByMember(ctx context.Context, vault string, engramID storage.ULID) (*Episode, error) {
+	ws := e.store.ResolveVaultPrefix(vault)
+
+	// BFS: collect all engram IDs connected via same_episode edges.
+	visited := map[storage.ULID]struct{}{engramID: {}}
+	queue := []storage.ULID{engramID}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		assocs, err := e.store.GetAssociations(ctx, ws, []storage.ULID{cur}, 0)
+		if err != nil {
+			return nil, fmt.Errorf("get episode by member: associations for %s: %w", cur, err)
+		}
+		for _, a := range assocs[cur] {
+			if a.RelType != storage.RelSameEpisode {
+				continue
+			}
+			if _, seen := visited[a.TargetID]; !seen {
+				visited[a.TargetID] = struct{}{}
+				queue = append(queue, a.TargetID)
+			}
+		}
+	}
+
+	if len(visited) == 0 {
+		return nil, fmt.Errorf("get episode by member: no episode found for %s", engramID)
+	}
+
+	// Collect IDs and fetch engrams.
+	ids := make([]storage.ULID, 0, len(visited))
+	for id := range visited {
+		ids = append(ids, id)
+	}
+	engrams, err := e.store.GetEngrams(ctx, ws, ids)
+	if err != nil {
+		return nil, fmt.Errorf("get episode by member: fetch engrams: %w", err)
+	}
+
+	var earliest, latest time.Time
+	var memberIDs []string
+	for _, eng := range engrams {
+		if eng == nil || eng.State == storage.StateSoftDeleted {
+			continue
+		}
+		memberIDs = append(memberIDs, eng.ID.String())
+		if earliest.IsZero() || eng.CreatedAt.Before(earliest) {
+			earliest = eng.CreatedAt
+		}
+		if latest.IsZero() || eng.CreatedAt.After(latest) {
+			latest = eng.CreatedAt
+		}
+	}
+	if len(memberIDs) == 0 {
+		return nil, fmt.Errorf("get episode by member: all members deleted for %s", engramID)
+	}
+
+	sort.Strings(memberIDs)
+
+	return &Episode{
+		ID:        memberIDs[0],
+		StartTime: earliest,
+		EndTime:   latest,
+		Size:      len(memberIDs),
+		Members:   memberIDs,
+	}, nil
 }

--- a/internal/engine/engine_episodes.go
+++ b/internal/engine/engine_episodes.go
@@ -1,0 +1,129 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/scrypster/muninndb/internal/storage"
+)
+
+// Episode represents a group of engrams connected by same_episode associations.
+type Episode struct {
+	ID        string    // ID of the first engram in the episode
+	StartTime time.Time
+	EndTime   time.Time
+	Size      int      // number of engrams
+	Members   []string // engram IDs (ULIDs as strings)
+}
+
+// ListEpisodes returns groups of engrams connected by same_episode associations.
+// It scans all forward associations in the vault, filters for RelSameEpisode,
+// builds connected components via union-find, and returns episodes sorted by
+// StartTime descending, limited to `limit`.
+func (e *Engine) ListEpisodes(ctx context.Context, vault string, limit int) ([]Episode, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	ws := e.store.ResolveVaultPrefix(vault)
+
+	// Phase 1: Scan all forward associations and collect same_episode edges.
+	type edge struct{ src, dst storage.ULID }
+	var edges []edge
+	allIDs := map[storage.ULID]struct{}{}
+
+	err := e.store.ScanAssociationsByType(ctx, ws, storage.RelSameEpisode, func(src, dst storage.ULID) error {
+		edges = append(edges, edge{src, dst})
+		allIDs[src] = struct{}{}
+		allIDs[dst] = struct{}{}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list episodes: scan associations: %w", err)
+	}
+	if len(edges) == 0 {
+		return []Episode{}, nil
+	}
+
+	// Phase 2: Union-find to build connected components.
+	parent := make(map[storage.ULID]storage.ULID, len(allIDs))
+	for id := range allIDs {
+		parent[id] = id
+	}
+	var find func(storage.ULID) storage.ULID
+	find = func(x storage.ULID) storage.ULID {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(a, b storage.ULID) {
+		ra, rb := find(a), find(b)
+		if ra != rb {
+			parent[ra] = rb
+		}
+	}
+	for _, e := range edges {
+		union(e.src, e.dst)
+	}
+
+	// Phase 3: Group by connected component root.
+	groups := map[storage.ULID][]storage.ULID{}
+	for id := range allIDs {
+		root := find(id)
+		groups[root] = append(groups[root], id)
+	}
+
+	// Phase 4: For each group, read engrams to get timestamps.
+	var episodes []Episode
+	for _, members := range groups {
+		// Fetch engrams in bulk.
+		engrams, err := e.store.GetEngrams(ctx, ws, members)
+		if err != nil {
+			continue // skip groups with read errors
+		}
+
+		var earliest, latest time.Time
+		var memberIDs []string
+		for _, eng := range engrams {
+			if eng == nil || eng.State == storage.StateSoftDeleted {
+				continue
+			}
+			memberIDs = append(memberIDs, eng.ID.String())
+			if earliest.IsZero() || eng.CreatedAt.Before(earliest) {
+				earliest = eng.CreatedAt
+			}
+			if latest.IsZero() || eng.CreatedAt.After(latest) {
+				latest = eng.CreatedAt
+			}
+		}
+		if len(memberIDs) == 0 {
+			continue
+		}
+
+		// Sort member IDs by ULID (lexicographic = chronological).
+		sort.Strings(memberIDs)
+
+		episodes = append(episodes, Episode{
+			ID:        memberIDs[0], // first engram chronologically
+			StartTime: earliest,
+			EndTime:   latest,
+			Size:      len(memberIDs),
+			Members:   memberIDs,
+		})
+	}
+
+	// Sort episodes by StartTime descending (most recent first).
+	sort.Slice(episodes, func(i, j int) bool {
+		return episodes[i].StartTime.After(episodes[j].StartTime)
+	})
+
+	if len(episodes) > limit {
+		episodes = episodes[:limit]
+	}
+	return episodes, nil
+}

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -199,7 +199,9 @@ func isReadOnlyTool(name string) bool {
 		"muninn_entity_timeline",
 		"muninn_provenance",
 		"muninn_entity",
-		"muninn_entities":
+		"muninn_entities",
+		"muninn_episodes",
+		"muninn_episode_members":
 		return true
 	}
 	return false

--- a/internal/mcp/engine.go
+++ b/internal/mcp/engine.go
@@ -176,4 +176,12 @@ type EngineInterface interface {
 	// CompleteEpisode walks same_episode associations from seedID to return
 	// all members of the episode, ordered by creation time ascending.
 	CompleteEpisode(ctx context.Context, vault string, seedID string) ([]engine.CompletedEngram, error)
+
+	// ListEpisodes returns groups of engrams connected by same_episode associations,
+	// sorted by StartTime descending. limit caps the number of episodes returned.
+	ListEpisodes(ctx context.Context, vault string, limit int) ([]EpisodeResult, error)
+
+	// GetEpisodeMembers returns full engrams for a specific episode, identified
+	// by the first engram ID in the episode.
+	GetEpisodeMembers(ctx context.Context, vault, episodeID string) ([]EpisodeMember, error)
 }

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -616,6 +616,63 @@ func (a *mcpEngineAdapter) DetectLoci(ctx context.Context, vault string, minEdge
 	return result, nil
 }
 
+func (a *mcpEngineAdapter) ListEpisodes(ctx context.Context, vault string, limit int) ([]EpisodeResult, error) {
+	episodes, err := a.eng.ListEpisodes(ctx, vault, limit)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]EpisodeResult, len(episodes))
+	for i, ep := range episodes {
+		results[i] = EpisodeResult{
+			ID:        ep.ID,
+			StartTime: ep.StartTime.UTC().Format(time.RFC3339),
+			EndTime:   ep.EndTime.UTC().Format(time.RFC3339),
+			Size:      ep.Size,
+			Members:   ep.Members,
+		}
+	}
+	return results, nil
+}
+
+func (a *mcpEngineAdapter) GetEpisodeMembers(ctx context.Context, vault, episodeID string) ([]EpisodeMember, error) {
+	// List all episodes and find the one matching episodeID.
+	episodes, err := a.eng.ListEpisodes(ctx, vault, 100)
+	if err != nil {
+		return nil, err
+	}
+	var memberIDs []string
+	for _, ep := range episodes {
+		if ep.ID == episodeID {
+			memberIDs = ep.Members
+			break
+		}
+	}
+	if memberIDs == nil {
+		return nil, fmt.Errorf("episode not found: %s", episodeID)
+	}
+
+	// Fetch each engram via the engine's public GetEngram method.
+	members := make([]EpisodeMember, 0, len(memberIDs))
+	for _, idStr := range memberIDs {
+		id, err := storage.ParseULID(idStr)
+		if err != nil {
+			continue
+		}
+		eng, err := a.eng.GetEngram(ctx, vault, id)
+		if err != nil || eng == nil {
+			continue
+		}
+		members = append(members, EpisodeMember{
+			ID:        eng.ID.String(),
+			Concept:   eng.Concept,
+			Summary:   eng.Summary,
+			State:     lifecycleStateLabel(eng.State),
+			CreatedAt: eng.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	return members, nil
+}
+
 func (a *mcpEngineAdapter) DetectLocusMembers(ctx context.Context, vault, locusLabel string, minEdgeWeight int) (*LocusMembersResult, error) {
 	loci, err := a.eng.DetectLoci(ctx, vault, minEdgeWeight)
 	if err != nil {

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -635,31 +635,29 @@ func (a *mcpEngineAdapter) ListEpisodes(ctx context.Context, vault string, limit
 }
 
 func (a *mcpEngineAdapter) GetEpisodeMembers(ctx context.Context, vault, episodeID string) ([]EpisodeMember, error) {
-	// List all episodes and find the one matching episodeID.
-	episodes, err := a.eng.ListEpisodes(ctx, vault, 100)
+	// Direct BFS lookup: walk same_episode edges from the episode's first engram.
+	// This avoids the recency limit imposed by ListEpisodes.
+	startID, err := storage.ParseULID(episodeID)
+	if err != nil {
+		return nil, fmt.Errorf("episode member %q: %w", episodeID, err)
+	}
+	episode, err := a.eng.GetEpisodeByMember(ctx, vault, startID)
 	if err != nil {
 		return nil, err
 	}
-	var memberIDs []string
-	for _, ep := range episodes {
-		if ep.ID == episodeID {
-			memberIDs = ep.Members
-			break
-		}
-	}
-	if memberIDs == nil {
-		return nil, fmt.Errorf("episode not found: %s", episodeID)
-	}
 
 	// Fetch each engram via the engine's public GetEngram method.
-	members := make([]EpisodeMember, 0, len(memberIDs))
-	for _, idStr := range memberIDs {
+	members := make([]EpisodeMember, 0, len(episode.Members))
+	for _, idStr := range episode.Members {
 		id, err := storage.ParseULID(idStr)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("episode member %q: %w", idStr, err)
 		}
 		eng, err := a.eng.GetEngram(ctx, vault, id)
-		if err != nil || eng == nil {
+		if err != nil {
+			return nil, fmt.Errorf("episode member %q: %w", idStr, err)
+		}
+		if eng == nil {
 			continue
 		}
 		members = append(members, EpisodeMember{

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1827,3 +1827,49 @@ func (s *MCPServer) handleEntityTimeline(ctx context.Context, w http.ResponseWri
 	}
 	sendResult(w, id, textContent(mustJSON(timeline)))
 }
+
+func (s *MCPServer) handleEpisodes(ctx context.Context, w http.ResponseWriter, id json.RawMessage, vault string, args map[string]any) {
+	limit := 10
+	if v, ok := args["limit"].(float64); ok {
+		limit = int(v)
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	episodes, err := s.engine.ListEpisodes(ctx, vault, limit)
+	if err != nil {
+		sendError(w, id, -32000, "tool error: "+err.Error())
+		return
+	}
+	if episodes == nil {
+		episodes = []EpisodeResult{}
+	}
+	sendResult(w, id, textContent(mustJSON(map[string]any{
+		"episodes": episodes,
+		"count":    len(episodes),
+	})))
+}
+
+func (s *MCPServer) handleEpisodeMembers(ctx context.Context, w http.ResponseWriter, id json.RawMessage, vault string, args map[string]any) {
+	episodeID, ok := args["episode_id"].(string)
+	if !ok || episodeID == "" {
+		sendError(w, id, -32602, "invalid params: 'episode_id' is required")
+		return
+	}
+	members, err := s.engine.GetEpisodeMembers(ctx, vault, episodeID)
+	if err != nil {
+		sendError(w, id, -32000, "tool error: "+err.Error())
+		return
+	}
+	if members == nil {
+		members = []EpisodeMember{}
+	}
+	sendResult(w, id, textContent(mustJSON(map[string]any{
+		"episode_id": episodeID,
+		"members":    members,
+		"count":      len(members),
+	})))
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -280,6 +280,10 @@ func (s *MCPServer) dispatchToolCall(ctx context.Context, w http.ResponseWriter,
 		// Entity aggregate view
 		"muninn_entity":   s.handleEntity,
 		"muninn_entities": s.handleEntities,
+
+		// Episode management
+		"muninn_episodes":        s.handleEpisodes,
+		"muninn_episode_members": s.handleEpisodeMembers,
 	}
 
 	handler, found := handlers[req.Params.Name]
@@ -309,6 +313,7 @@ func registeredToolNames() []string {
 		"muninn_similar_entities", "muninn_merge_entity", "muninn_entity_timeline",
 		"muninn_replay_enrichment", "muninn_provenance", "muninn_feedback",
 		"muninn_entity", "muninn_entities",
+		"muninn_episodes", "muninn_episode_members",
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -189,6 +189,12 @@ func (f *fakeEngine) DetectLocusMembers(_ context.Context, _, _ string, _ int) (
 func (f *fakeEngine) CompleteEpisode(_ context.Context, _ string, _ string) ([]engine.CompletedEngram, error) {
 	return nil, nil
 }
+func (f *fakeEngine) ListEpisodes(_ context.Context, _ string, _ int) ([]EpisodeResult, error) {
+	return []EpisodeResult{}, nil
+}
+func (f *fakeEngine) GetEpisodeMembers(_ context.Context, _, _ string) ([]EpisodeMember, error) {
+	return []EpisodeMember{}, nil
+}
 
 func newTestServer() *MCPServer {
 	return New(":0", &fakeEngine{}, "", nil, nil)
@@ -287,8 +293,8 @@ func TestListTools(t *testing.T) {
 	var result map[string]any
 	json.NewDecoder(w.Body).Decode(&result)
 	tools, _ := result["tools"].([]any)
-	if len(tools) != 40 {
-		t.Errorf("expected 40 tools, got %d", len(tools))
+	if len(tools) != 42 {
+		t.Errorf("expected 42 tools, got %d", len(tools))
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -824,5 +824,30 @@ func allToolDefinitions() []ToolDefinition {
 				"required": []string{},
 			},
 		},
+		// Episode management tools
+		{
+			Name:        "muninn_episodes",
+			Description: "List recent episodes in a vault. Episodes are groups of consecutive memories linked by same_episode associations during hippocampal episode segmentation. Returns episodes sorted by start time (most recent first).",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"vault": vaultProp,
+					"limit": map[string]any{"type": "integer", "description": "Max episodes to return (default 10, max 100)."},
+				},
+				"required": []string{},
+			},
+		},
+		{
+			Name:        "muninn_episode_members",
+			Description: "Get full engram details for all members of a specific episode. Use muninn_episodes first to discover episodes, then pass an episode ID here to see its contents.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"vault":      vaultProp,
+					"episode_id": map[string]any{"type": "string", "description": "ID of the episode (first engram ID from muninn_episodes output)."},
+				},
+				"required": []string{"episode_id"},
+			},
+		},
 	}
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestAllToolDefinitionsCount(t *testing.T) {
 	tools := allToolDefinitions()
-	if len(tools) != 40 {
-		t.Errorf("expected 40 tools, got %d", len(tools))
+	if len(tools) != 42 {
+		t.Errorf("expected 42 tools, got %d", len(tools))
 	}
 }
 
@@ -102,6 +102,9 @@ func TestExpectedToolNames(t *testing.T) {
 		// Entity aggregate view
 		"muninn_entity",
 		"muninn_entities",
+		// Episode management
+		"muninn_episodes",
+		"muninn_episode_members",
 	}
 	for _, name := range expected {
 		if !names[name] {

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -469,3 +469,21 @@ type EntitySummary struct {
 	MentionCount int32   `json:"mention_count"`
 	FirstSeen    string  `json:"first_seen,omitempty"` // RFC3339
 }
+
+// EpisodeResult is one episode returned by muninn_episodes.
+type EpisodeResult struct {
+	ID        string `json:"id"`         // ID of the first engram in the episode
+	StartTime string `json:"start_time"` // RFC3339
+	EndTime   string `json:"end_time"`   // RFC3339
+	Size      int    `json:"size"`       // number of engrams
+	Members   []string `json:"members"`  // engram IDs (ULIDs as strings)
+}
+
+// EpisodeMember is one engram within an episode, returned by muninn_episode_members.
+type EpisodeMember struct {
+	ID        string `json:"id"`
+	Concept   string `json:"concept"`
+	Summary   string `json:"summary,omitempty"`
+	State     string `json:"state"`
+	CreatedAt string `json:"created_at"` // RFC3339
+}

--- a/internal/storage/association.go
+++ b/internal/storage/association.go
@@ -877,3 +877,39 @@ func (ps *PebbleStore) GetContradictions(ctx context.Context, wsPrefix [8]byte) 
 	}
 	return pairs, nil
 }
+
+// ScanAssociationsByType scans all forward associations (0x03 prefix) in a vault
+// and calls fn for each edge whose RelType matches relType. This is an O(all-assocs)
+// scan — use sparingly. The fn callback receives (sourceID, targetID).
+func (ps *PebbleStore) ScanAssociationsByType(ctx context.Context, wsPrefix [8]byte, relType RelType, fn func(src, dst ULID) error) error {
+	lower := keys.AssocFwdRangeStart(wsPrefix)
+	upper := keys.AssocFwdRangeEnd(wsPrefix)
+	iter, err := ps.db.NewIter(&pebble.IterOptions{
+		LowerBound: lower,
+		UpperBound: upper,
+	})
+	if err != nil {
+		return fmt.Errorf("scan assoc by type: create iter: %w", err)
+	}
+	defer iter.Close()
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		k := iter.Key()
+		// Key layout: 0x03 | ws(8) | srcID(16) | weightComplement(4) | dstID(16) = 45 bytes
+		if len(k) < 45 {
+			continue
+		}
+		val := iter.Value()
+		rt, _, _, _, _, _, _ := decodeAssocValue(val)
+		if rt != relType {
+			continue
+		}
+		var src, dst ULID
+		copy(src[:], k[9:25])
+		copy(dst[:], k[29:45])
+		if err := fn(src, dst); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds MCP tools for querying and navigating episodes created by the EpisodeWorker (#12).

### What's implemented
- **`muninn_episodes`** — list recent episodes in a vault (ID, start/end time, size, member IDs)
- **`muninn_episode_members`** — get full engrams for a specific episode (concept, summary, state, timestamps)
- **`Engine.ListEpisodes()`** — union-find over `same_episode` associations to discover connected components
- **`PebbleStore.ScanAssociationsByType()`** — new storage method that scans forward associations (0x03) filtered by RelType
- Both tools are read-only

### Design
Episodes are discovered by scanning all `same_episode` (0x0011) associations in the vault's forward index, building a union-find data structure to group connected engrams, then fetching timestamps to compute episode boundaries. Results are sorted by start time descending.

### Files changed
| Layer | Files |
|---|---|
| Storage | `association.go` (+ScanAssociationsByType) |
| Engine | `engine_episodes.go` (new: ListEpisodes, Episode struct) |
| MCP | `tools.go`, `handlers.go`, `engine.go`, `engine_adapter.go`, `types.go`, `server.go`, `context.go`, `server_test.go`, `tools_test.go` |

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List recent episodes with configurable limits (default 10, max 100); episodes show start/end timestamps, size, and member IDs.
  * Retrieve full member details for a chosen episode, including concept, state, summary, and created-at timestamps.
  * New API endpoints to list episodes and fetch episode members.

* **Tests**
  * Updated test coverage to validate the new episode listing and member-retrieval functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->