### PR TITLE
feat(cognitive): consolidation during replay

### DIFF
--- a/internal/cognitive/hippocampal.go
+++ b/internal/cognitive/hippocampal.go
@@ -88,14 +88,25 @@ type ReplayConfig struct {
 	// MaxEngrams is the maximum number of recent engrams to replay per vault
 	// per cycle. Default: 100.
 	MaxEngrams int `json:"max_engrams"`
+
+	// EnableConsolidation generates episode summaries during replay.
+	// When true, the replay cycle will identify episode clusters and produce
+	// consolidated summary engrams — the hippocampal→neocortical transfer.
+	EnableConsolidation bool `json:"enable_consolidation"`
+
+	// ConsolidationMinSize is the minimum number of episode members required
+	// to trigger summary generation. Default: 3.
+	ConsolidationMinSize int `json:"consolidation_min_size"`
 }
 
 // DefaultReplayConfig returns a ReplayConfig with production-ready defaults.
 func DefaultReplayConfig() ReplayConfig {
 	return ReplayConfig{
-		Interval:     6 * time.Hour,
-		LearningRate: 0.005,
-		MaxEngrams:   100,
+		Interval:             6 * time.Hour,
+		LearningRate:         0.005,
+		MaxEngrams:           100,
+		EnableConsolidation:  false,
+		ConsolidationMinSize: 3,
 	}
 }
 

--- a/internal/cognitive/replay.go
+++ b/internal/cognitive/replay.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -19,6 +20,30 @@ type ReplayActivator interface {
 type ReplayStore interface {
 	ListVaults(ctx context.Context) ([]string, error)
 	RecentEngrams(ctx context.Context, vault string, limit int) ([]ReplayEngram, error)
+}
+
+// ConsolidationStore provides episode access and summary storage for the
+// hippocampal→neocortical consolidation path during replay.
+type ConsolidationStore interface {
+	// GetEpisodeConcepts returns the concepts of engrams in an episode
+	// identified by seedID (the first member's ULID string).
+	GetEpisodeConcepts(ctx context.Context, vault string, seedID string) ([]string, error)
+
+	// StoreConsolidation persists a summary engram and links it to episode
+	// members via RelIsPartOf associations.
+	StoreConsolidation(ctx context.Context, vault string, summary string, memberIDs []string) error
+}
+
+// noopConsolidationStore is a no-op implementation used when no real store is
+// wired. All operations succeed without side effects.
+type noopConsolidationStore struct{}
+
+func (noopConsolidationStore) GetEpisodeConcepts(_ context.Context, _ string, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (noopConsolidationStore) StoreConsolidation(_ context.Context, _ string, _ string, _ []string) error {
+	return nil
 }
 
 // ReplayEngram is the minimal engram representation needed for replay.
@@ -47,11 +72,12 @@ type ReplayMetrics struct {
 // It is NOT an event-driven Worker[T]. It follows the periodic background
 // goroutine pattern (like runPruneWorker / runCoherenceFlush).
 type ReplayWorker struct {
-	config    ReplayConfig
-	activator ReplayActivator
-	store     ReplayStore
-	stopCh    chan struct{}
-	done      chan struct{}
+	config             ReplayConfig
+	activator          ReplayActivator
+	store              ReplayStore
+	consolidationStore ConsolidationStore
+	stopCh             chan struct{}
+	done               chan struct{}
 
 	// metrics — thread-safe via sync/atomic
 	cyclesCompleted atomic.Uint64
@@ -65,11 +91,20 @@ type ReplayWorker struct {
 // NewReplayWorker creates a new hippocampal replay worker.
 func NewReplayWorker(config ReplayConfig, activator ReplayActivator, store ReplayStore) *ReplayWorker {
 	return &ReplayWorker{
-		config:    config,
-		activator: activator,
-		store:     store,
-		stopCh:    make(chan struct{}),
-		done:      make(chan struct{}),
+		config:             config,
+		activator:          activator,
+		store:              store,
+		consolidationStore: noopConsolidationStore{},
+		stopCh:             make(chan struct{}),
+		done:               make(chan struct{}),
+	}
+}
+
+// SetConsolidationStore wires a real ConsolidationStore for episode summary
+// generation during replay. Call before Run().
+func (rw *ReplayWorker) SetConsolidationStore(cs ConsolidationStore) {
+	if cs != nil {
+		rw.consolidationStore = cs
 	}
 }
 
@@ -199,6 +234,83 @@ func (rw *ReplayWorker) replayCycle(ctx context.Context) {
 		}
 	}
 
-	slog.Info("replay: consolidation cycle complete",
+	slog.Info("replay: activation pass complete",
 		"total_activated", totalActivated)
+
+	// Phase 2: Consolidation — generate episode summaries if enabled.
+	if rw.config.EnableConsolidation {
+		rw.consolidateCycle(ctx, vaults)
+	}
+}
+
+// consolidateCycle runs the consolidation pass across all vaults, generating
+// summary engrams for episodes that meet the minimum size threshold.
+func (rw *ReplayWorker) consolidateCycle(ctx context.Context, vaults []string) {
+	minSize := rw.config.ConsolidationMinSize
+	if minSize <= 0 {
+		minSize = 3
+	}
+
+	var totalConsolidated int
+	for _, vault := range vaults {
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Use RecentEngrams as seed IDs. Each engram might belong to an episode;
+		// we deduplicate by tracking which seedIDs we've already consolidated.
+		engrams, err := rw.store.RecentEngrams(ctx, vault, rw.config.MaxEngrams)
+		if err != nil {
+			slog.Warn("replay: consolidation: failed to get recent engrams",
+				"vault", vault, "error", err)
+			continue
+		}
+
+		consolidated := map[string]bool{} // track processed seedIDs
+		for _, eg := range engrams {
+			if ctx.Err() != nil {
+				return
+			}
+
+			seedID := fmt.Sprintf("%x", eg.ID)
+			if consolidated[seedID] {
+				continue
+			}
+
+			concepts, err := rw.consolidationStore.GetEpisodeConcepts(ctx, vault, seedID)
+			if err != nil {
+				slog.Debug("replay: consolidation: get episode concepts failed",
+					"vault", vault, "seed", seedID, "error", err)
+				continue
+			}
+			if len(concepts) < minSize {
+				consolidated[seedID] = true
+				continue
+			}
+
+			summary := buildConsolidationSummary(concepts)
+			if err := rw.consolidationStore.StoreConsolidation(ctx, vault, summary, nil); err != nil {
+				slog.Warn("replay: consolidation: store failed",
+					"vault", vault, "seed", seedID, "error", err)
+				continue
+			}
+
+			consolidated[seedID] = true
+			totalConsolidated++
+
+			slog.Debug("replay: consolidated episode",
+				"vault", vault, "seed", seedID, "members", len(concepts))
+		}
+	}
+
+	if totalConsolidated > 0 {
+		slog.Info("replay: consolidation pass complete",
+			"total_consolidated", totalConsolidated)
+	}
+}
+
+// buildConsolidationSummary generates a simple summary from episode member concepts.
+// No LLM dependency — concatenates concepts with semicolons.
+func buildConsolidationSummary(concepts []string) string {
+	return "Episode summary: " + strings.Join(concepts, "; ")
 }

--- a/internal/cognitive/replay.go
+++ b/internal/cognitive/replay.go
@@ -24,6 +24,10 @@ type ReplayStore interface {
 
 // ConsolidationStore provides episode access and summary storage for the
 // hippocampal→neocortical consolidation path during replay.
+//
+// TODO: Return episode ID and member IDs alongside concepts for dedup and
+// RelIsPartOf linking. Current simplified interface is sufficient for the noop
+// default and will be expanded when wiring the real store.
 type ConsolidationStore interface {
 	// GetEpisodeConcepts returns the concepts of engrams in an episode
 	// identified by seedID (the first member's ULID string).
@@ -102,6 +106,10 @@ func NewReplayWorker(config ReplayConfig, activator ReplayActivator, store Repla
 
 // SetConsolidationStore wires a real ConsolidationStore for episode summary
 // generation during replay. Call before Run().
+//
+// Note: EnableConsolidation in ReplayConfig has no effect without calling
+// SetConsolidationStore with a non-nil, non-noop implementation. The default
+// noopConsolidationStore silently discards all consolidation operations.
 func (rw *ReplayWorker) SetConsolidationStore(cs ConsolidationStore) {
 	if cs != nil {
 		rw.consolidationStore = cs
@@ -246,6 +254,11 @@ func (rw *ReplayWorker) replayCycle(ctx context.Context) {
 // consolidateCycle runs the consolidation pass across all vaults, generating
 // summary engrams for episodes that meet the minimum size threshold.
 func (rw *ReplayWorker) consolidateCycle(ctx context.Context, vaults []string) {
+	if _, isNoop := rw.consolidationStore.(noopConsolidationStore); isNoop {
+		slog.Warn("replay: consolidation enabled but no real store wired (call SetConsolidationStore)")
+		return
+	}
+
 	minSize := rw.config.ConsolidationMinSize
 	if minSize <= 0 {
 		minSize = 3

--- a/internal/cognitive/replay_consolidation_test.go
+++ b/internal/cognitive/replay_consolidation_test.go
@@ -1,0 +1,170 @@
+package cognitive
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mockConsolidationStore records calls and returns configurable episode data.
+type mockConsolidationStore struct {
+	mu       sync.Mutex
+	episodes map[string][]string // seedID → concepts
+	stored   []consolidationRecord
+}
+
+type consolidationRecord struct {
+	vault   string
+	summary string
+}
+
+func (m *mockConsolidationStore) GetEpisodeConcepts(_ context.Context, _ string, seedID string) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.episodes[seedID], nil
+}
+
+func (m *mockConsolidationStore) StoreConsolidation(_ context.Context, vault string, summary string, _ []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stored = append(m.stored, consolidationRecord{vault: vault, summary: summary})
+	return nil
+}
+
+func (m *mockConsolidationStore) getStored() []consolidationRecord {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]consolidationRecord, len(m.stored))
+	copy(out, m.stored)
+	return out
+}
+
+func TestConsolidationSkipsSmallEpisodes(t *testing.T) {
+	activator := &mockReplayActivator{}
+	// Engram with seedID "01000000000000000000000000000000" (hex of [16]byte{1})
+	store := &mockReplayStore{
+		vaults: []string{"test-vault"},
+		engrams: map[string][]ReplayEngram{
+			"test-vault": {
+				{ID: [16]byte{1}, Concept: "small-ep", Content: "content", Vault: "test-vault"},
+			},
+		},
+	}
+	cs := &mockConsolidationStore{
+		episodes: map[string][]string{
+			"01000000000000000000000000000000": {"concept-a", "concept-b"}, // only 2 members
+		},
+	}
+
+	cfg := ReplayConfig{
+		Interval:             20 * time.Millisecond,
+		LearningRate:         0.005,
+		MaxEngrams:           100,
+		EnableConsolidation:  true,
+		ConsolidationMinSize: 3,
+	}
+	rw := NewReplayWorker(cfg, activator, store)
+	rw.SetConsolidationStore(cs)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go rw.Run(ctx)
+
+	// Wait for at least one cycle with activation.
+	deadline := time.After(3 * time.Second)
+	for {
+		calls := activator.getCalls()
+		if len(calls) >= 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected at least 1 activate call")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	<-rw.Done()
+
+	// Episode had only 2 members, minSize is 3 — no consolidation should occur.
+	stored := cs.getStored()
+	if len(stored) != 0 {
+		t.Errorf("expected 0 consolidation records for small episode, got %d: %+v", len(stored), stored)
+	}
+}
+
+func TestConsolidationGeneratesSummary(t *testing.T) {
+	activator := &mockReplayActivator{}
+	store := &mockReplayStore{
+		vaults: []string{"test-vault"},
+		engrams: map[string][]ReplayEngram{
+			"test-vault": {
+				{ID: [16]byte{1}, Concept: "big-ep", Content: "content", Vault: "test-vault"},
+			},
+		},
+	}
+	cs := &mockConsolidationStore{
+		episodes: map[string][]string{
+			"01000000000000000000000000000000": {"meeting notes", "action items", "deadline reminder"},
+		},
+	}
+
+	cfg := ReplayConfig{
+		Interval:             20 * time.Millisecond,
+		LearningRate:         0.005,
+		MaxEngrams:           100,
+		EnableConsolidation:  true,
+		ConsolidationMinSize: 3,
+	}
+	rw := NewReplayWorker(cfg, activator, store)
+	rw.SetConsolidationStore(cs)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go rw.Run(ctx)
+
+	// Wait for at least one consolidation to be stored.
+	deadline := time.After(3 * time.Second)
+	for {
+		stored := cs.getStored()
+		if len(stored) >= 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected at least 1 consolidation record")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	<-rw.Done()
+
+	stored := cs.getStored()
+	if len(stored) == 0 {
+		t.Fatal("expected consolidation records, got none")
+	}
+
+	rec := stored[0]
+	if rec.vault != "test-vault" {
+		t.Errorf("expected vault 'test-vault', got %q", rec.vault)
+	}
+	if !strings.HasPrefix(rec.summary, "Episode summary: ") {
+		t.Errorf("expected summary to start with 'Episode summary: ', got %q", rec.summary)
+	}
+	if !strings.Contains(rec.summary, "meeting notes") {
+		t.Errorf("expected summary to contain 'meeting notes', got %q", rec.summary)
+	}
+	if !strings.Contains(rec.summary, "action items") {
+		t.Errorf("expected summary to contain 'action items', got %q", rec.summary)
+	}
+	if !strings.Contains(rec.summary, "deadline reminder") {
+		t.Errorf("expected summary to contain 'deadline reminder', got %q", rec.summary)
+	}
+
+	expectedSummary := "Episode summary: meeting notes; action items; deadline reminder"
+	if rec.summary != expectedSummary {
+		t.Errorf("summary mismatch:\n  got:  %q\n  want: %q", rec.summary, expectedSummary)
+	}
+}


### PR DESCRIPTION
## Summary

Adds **consolidation during replay** — the hippocampal→neocortical memory transfer mechanism. During replay cycles, generates simple episode summaries from member concepts.

### What's implemented
- **`EnableConsolidation`** + **`ConsolidationMinSize`** (default 3) in ReplayConfig
- **`ConsolidationStore`** interface — `GetEpisodeConcepts` + `StoreConsolidation`
- **`noopConsolidationStore`** default — zero changes to existing engine wiring
- **`consolidateCycle()`** — runs after synthetic activation, generates summaries for qualifying episodes
- **`buildConsolidationSummary()`** — simple concept concatenation ("Episode summary: concept1; concept2; concept3"), no LLM dependency
- **`SetConsolidationStore()`** — inject real store after construction
- **2 tests** — skip small episodes, generate correct summaries

### Design decisions
- No LLM required — summaries are concept concatenation. LLM-powered summaries can be added via the enrich plugin later.
- Backward compatible — NewReplayWorker signature unchanged, noop store by default
- Real engine wiring (CompleteEpisode + Remember pipeline) left as TODO for integration PR

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added memory consolidation feature to cognitive replay system with configurable settings
  * Automatically generates episode summaries during consolidation cycles based on concept data
  * Introduces minimum episode size threshold to control consolidation activation
  * Includes test coverage for consolidation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->