### PR TITLE
feat(cognitive): narrative assembly for episode completion

### DIFF
--- a/internal/engine/engine_completion.go
+++ b/internal/engine/engine_completion.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/scrypster/muninndb/internal/storage"
 )
@@ -17,6 +19,16 @@ type CompletedEngram struct {
 	Summary   string
 	State     string
 	CreatedAt time.Time
+}
+
+// NarrativeContext provides structured context around a completed episode:
+// what came before, what came after, how long it lasted, and its theme.
+type NarrativeContext struct {
+	Members  []CompletedEngram // episode members sorted by creation time
+	BeforeID string            // engram ID immediately before the episode (empty if none)
+	AfterID  string            // engram ID immediately after the episode (empty if none)
+	Duration time.Duration     // time span of the episode
+	TopicHint string           // most common concept words across members
 }
 
 // CompleteEpisode takes a seed engram ID and walks same_episode associations
@@ -112,4 +124,141 @@ func (e *Engine) CompleteEpisode(ctx context.Context, vault string, seedID strin
 	})
 
 	return result, nil
+}
+
+// CompleteEpisodeWithContext returns the full episode like CompleteEpisode, but
+// also provides narrative context: boundary engrams (before/after), duration,
+// and a topic hint derived from word frequency across member concepts.
+func (e *Engine) CompleteEpisodeWithContext(ctx context.Context, vault string, seedID string) (*NarrativeContext, error) {
+	members, err := e.CompleteEpisode(ctx, vault, seedID)
+	if err != nil {
+		return nil, err
+	}
+	if len(members) == 0 {
+		return &NarrativeContext{}, nil
+	}
+
+	wsPrefix := e.store.ResolveVaultPrefix(vault)
+
+	first := members[0]
+	last := members[len(members)-1]
+
+	nc := &NarrativeContext{
+		Members:  members,
+		Duration: last.CreatedAt.Sub(first.CreatedAt),
+	}
+
+	// Find the engram immediately before the episode.
+	// Scan a small window ending just before the first member's timestamp.
+	if beforeIDs, err := e.store.EngramIDsByCreatedRange(
+		ctx, wsPrefix,
+		first.CreatedAt.Add(-30*time.Minute), // look back up to 30 minutes
+		first.CreatedAt.Add(-time.Millisecond),
+		50,
+	); err == nil && len(beforeIDs) > 0 {
+		// Take the last (most recent) ID that is not itself an episode member.
+		memberSet := make(map[string]struct{}, len(members))
+		for _, m := range members {
+			memberSet[m.ID] = struct{}{}
+		}
+		for i := len(beforeIDs) - 1; i >= 0; i-- {
+			idStr := beforeIDs[i].String()
+			if _, isMember := memberSet[idStr]; !isMember {
+				nc.BeforeID = idStr
+				break
+			}
+		}
+	}
+
+	// Find the engram immediately after the episode.
+	if afterIDs, err := e.store.EngramIDsByCreatedRange(
+		ctx, wsPrefix,
+		last.CreatedAt.Add(time.Millisecond),
+		last.CreatedAt.Add(30*time.Minute), // look ahead up to 30 minutes
+		50,
+	); err == nil && len(afterIDs) > 0 {
+		memberSet := make(map[string]struct{}, len(members))
+		for _, m := range members {
+			memberSet[m.ID] = struct{}{}
+		}
+		for _, id := range afterIDs {
+			idStr := id.String()
+			if _, isMember := memberSet[idStr]; !isMember {
+				nc.AfterID = idStr
+				break
+			}
+		}
+	}
+
+	// Generate TopicHint from word frequency across member concepts.
+	nc.TopicHint = topicHintFromConcepts(members)
+
+	return nc, nil
+}
+
+// topicHintFromConcepts extracts the 3 most common non-trivial words from
+// the Concept fields of the episode members.
+func topicHintFromConcepts(members []CompletedEngram) string {
+	freq := make(map[string]int)
+	for _, m := range members {
+		for _, word := range conceptWords(m.Concept) {
+			freq[word]++
+		}
+	}
+	if len(freq) == 0 {
+		return ""
+	}
+
+	type wc struct {
+		word  string
+		count int
+	}
+	var pairs []wc
+	for w, c := range freq {
+		pairs = append(pairs, wc{w, c})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].count != pairs[j].count {
+			return pairs[i].count > pairs[j].count
+		}
+		return pairs[i].word < pairs[j].word // stable tie-break
+	})
+
+	n := 3
+	if len(pairs) < n {
+		n = len(pairs)
+	}
+	words := make([]string, n)
+	for i := 0; i < n; i++ {
+		words[i] = pairs[i].word
+	}
+	return strings.Join(words, ", ")
+}
+
+// stopWords is a small set of common English words filtered from topic hints.
+var stopWords = map[string]struct{}{
+	"a": {}, "an": {}, "the": {}, "and": {}, "or": {}, "but": {},
+	"in": {}, "on": {}, "at": {}, "to": {}, "for": {}, "of": {},
+	"is": {}, "it": {}, "by": {}, "with": {}, "as": {}, "from": {},
+	"that": {}, "this": {}, "was": {}, "are": {}, "be": {}, "has": {},
+	"had": {}, "not": {}, "no": {}, "do": {}, "if": {}, "so": {},
+}
+
+// conceptWords splits a concept string into lowercase words, filtering out
+// stop words and very short tokens.
+func conceptWords(concept string) []string {
+	var words []string
+	for _, raw := range strings.FieldsFunc(concept, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		w := strings.ToLower(raw)
+		if len(w) < 3 {
+			continue
+		}
+		if _, stop := stopWords[w]; stop {
+			continue
+		}
+		words = append(words, w)
+	}
+	return words
 }

--- a/internal/mcp/engine.go
+++ b/internal/mcp/engine.go
@@ -177,6 +177,10 @@ type EngineInterface interface {
 	// all members of the episode, ordered by creation time ascending.
 	CompleteEpisode(ctx context.Context, vault string, seedID string) ([]engine.CompletedEngram, error)
 
+	// CompleteEpisodeWithContext returns the full episode plus narrative context:
+	// boundary engrams, duration, and topic hint.
+	CompleteEpisodeWithContext(ctx context.Context, vault string, seedID string) (*engine.NarrativeContext, error)
+
 	// ListEpisodes returns groups of engrams connected by same_episode associations,
 	// sorted by StartTime descending. limit caps the number of episodes returned.
 	ListEpisodes(ctx context.Context, vault string, limit int) ([]EpisodeResult, error)

--- a/internal/mcp/engine_adapter.go
+++ b/internal/mcp/engine_adapter.go
@@ -755,10 +755,15 @@ func convertTreeNodeInput(n TreeNodeInput) engine.TreeNodeInput {
 	return out
 }
 
-// convertTreeNode converts engine.TreeNode → mcp.TreeNode recursively.
 func (a *mcpEngineAdapter) CompleteEpisode(ctx context.Context, vault string, seedID string) ([]engine.CompletedEngram, error) {
 	return a.eng.CompleteEpisode(ctx, vault, seedID)
 }
+
+func (a *mcpEngineAdapter) CompleteEpisodeWithContext(ctx context.Context, vault string, seedID string) (*engine.NarrativeContext, error) {
+	return a.eng.CompleteEpisodeWithContext(ctx, vault, seedID)
+}
+
+// convertTreeNode converts engine.TreeNode → mcp.TreeNode recursively.
 
 func convertTreeNode(n *engine.TreeNode) *TreeNode {
 	if n == nil {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -380,16 +380,17 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 	}
 
 	// Pattern completion mode: take the top activation result and return
-	// all members of its episode via same_episode association walking.
+	// all members of its episode via same_episode association walking,
+	// enriched with narrative context (boundary engrams, duration, topic hint).
 	if completionMode && len(resp.Activations) > 0 {
 		seedID := resp.Activations[0].ID
-		episode, epErr := s.engine.CompleteEpisode(ctx, vault, seedID)
+		nc, epErr := s.engine.CompleteEpisodeWithContext(ctx, vault, seedID)
 		if epErr != nil {
 			sendError(w, id, -32000, "completion error: "+epErr.Error())
 			return
 		}
 		var memories []Memory
-		for _, ce := range episode {
+		for _, ce := range nc.Members {
 			memories = append(memories, Memory{
 				ID:        ce.ID,
 				Concept:   ce.Concept,
@@ -400,12 +401,26 @@ func (s *MCPServer) handleRecall(ctx context.Context, w http.ResponseWriter, id 
 			})
 		}
 		result := map[string]any{
-			"memories":  memories,
-			"total":     len(memories),
-			"mode":      "complete",
-			"seed_id":   seedID,
+			"memories":   memories,
+			"total":      len(memories),
+			"mode":       "complete",
+			"seed_id":    seedID,
 			"seed_score": resp.Activations[0].Score,
 		}
+		// Narrative context fields.
+		narrative := map[string]any{
+			"duration_ms": nc.Duration.Milliseconds(),
+		}
+		if nc.BeforeID != "" {
+			narrative["before_id"] = nc.BeforeID
+		}
+		if nc.AfterID != "" {
+			narrative["after_id"] = nc.AfterID
+		}
+		if nc.TopicHint != "" {
+			narrative["topic_hint"] = nc.TopicHint
+		}
+		result["narrative"] = narrative
 		if len(memories) == 0 {
 			result["hint"] = "Top activation result has no episode associations. Try mode='ranked' or use muninn_traverse to explore its neighbourhood."
 		}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -189,6 +189,9 @@ func (f *fakeEngine) DetectLocusMembers(_ context.Context, _, _ string, _ int) (
 func (f *fakeEngine) CompleteEpisode(_ context.Context, _ string, _ string) ([]engine.CompletedEngram, error) {
 	return nil, nil
 }
+func (f *fakeEngine) CompleteEpisodeWithContext(_ context.Context, _ string, _ string) (*engine.NarrativeContext, error) {
+	return &engine.NarrativeContext{}, nil
+}
 func (f *fakeEngine) ListEpisodes(_ context.Context, _ string, _ int) ([]EpisodeResult, error) {
 	return []EpisodeResult{}, nil
 }


### PR DESCRIPTION
## Summary

Enhances pattern completion mode with **narrative context** — boundary engrams, duration, and topic hints for coherent episode reconstruction.

### What's implemented
- **`NarrativeContext`** struct — `BeforeID`, `AfterID`, `Duration`, `TopicHint`
- **`CompleteEpisodeWithContext()`** — walks episode + scans 30min windows for boundary engrams
- **`TopicHint`** — word frequency across member concepts (stop-word filtered, top 3)
- **Completion response** now includes `narrative` object with `duration_ms`, boundary IDs, topic hint

### Design
- No LLM dependency — topic hints from simple word frequency
- Boundary detection via `EngramIDsByCreatedRange` (time-window scan)
- Backward compatible — existing completion mode still works, narrative adds context

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Episode completion now returns enriched narrative context, including episode duration, surrounding context boundaries, and an automatically derived topic hint based on member concepts.
  * Response payload extended with a new `narrative` object containing duration and optional contextual metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->