### PR TITLE
feat(cognitive): replay effectiveness metrics

### DIFF
--- a/internal/cognitive/replay.go
+++ b/internal/cognitive/replay.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 	"time"
 )
 
@@ -28,6 +29,17 @@ type ReplayEngram struct {
 	Vault   string
 }
 
+// ReplayMetrics holds effectiveness counters for the replay worker.
+// All fields are read via atomic loads and are safe for concurrent access.
+type ReplayMetrics struct {
+	CyclesCompleted   uint64        // total replay cycles run
+	EngramsReplayed   uint64        // total engrams replayed across all cycles
+	VaultsProcessed   uint64        // total vaults processed
+	LastCycleDuration time.Duration // wall-clock duration of most recent cycle
+	LastCycleAt       time.Time     // completion time of most recent cycle
+	Errors            uint64        // activation errors during replay
+}
+
 // ReplayWorker periodically runs synthetic ACTIVATE calls on recent engrams
 // to strengthen Hebbian associations and trigger PAS transitions. This is the
 // biological analogue of hippocampal sleep replay / memory consolidation.
@@ -40,6 +52,14 @@ type ReplayWorker struct {
 	store     ReplayStore
 	stopCh    chan struct{}
 	done      chan struct{}
+
+	// metrics — thread-safe via sync/atomic
+	cyclesCompleted atomic.Uint64
+	engramsReplayed atomic.Uint64
+	vaultsProcessed atomic.Uint64
+	lastCycleDur    atomic.Int64 // stored as time.Duration (int64 nanoseconds)
+	lastCycleAt     atomic.Int64 // stored as UnixNano
+	errors          atomic.Uint64
 }
 
 // NewReplayWorker creates a new hippocampal replay worker.
@@ -87,12 +107,35 @@ func (rw *ReplayWorker) Done() <-chan struct{} {
 	return rw.done
 }
 
+// Metrics returns a snapshot of the replay effectiveness counters.
+// Safe to call concurrently while the worker is running.
+func (rw *ReplayWorker) Metrics() ReplayMetrics {
+	var lastAt time.Time
+	if nanos := rw.lastCycleAt.Load(); nanos != 0 {
+		lastAt = time.Unix(0, nanos)
+	}
+	return ReplayMetrics{
+		CyclesCompleted:   rw.cyclesCompleted.Load(),
+		EngramsReplayed:   rw.engramsReplayed.Load(),
+		VaultsProcessed:   rw.vaultsProcessed.Load(),
+		LastCycleDuration: time.Duration(rw.lastCycleDur.Load()),
+		LastCycleAt:       lastAt,
+		Errors:            rw.errors.Load(),
+	}
+}
+
 // replayCycle runs one full replay pass across all vaults.
 func (rw *ReplayWorker) replayCycle(ctx context.Context) {
+	cycleStart := time.Now()
+
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("replay: cycle panicked", "panic", r)
 		}
+		// Record cycle timing regardless of success/panic.
+		rw.lastCycleDur.Store(int64(time.Since(cycleStart)))
+		rw.lastCycleAt.Store(time.Now().UnixNano())
+		rw.cyclesCompleted.Add(1)
 	}()
 
 	vaults, err := rw.store.ListVaults(ctx)
@@ -122,6 +165,8 @@ func (rw *ReplayWorker) replayCycle(ctx context.Context) {
 			continue
 		}
 
+		rw.vaultsProcessed.Add(1)
+
 		slog.Debug("replay: replaying vault",
 			"vault", vault, "engrams", len(engrams))
 
@@ -142,12 +187,14 @@ func (rw *ReplayWorker) replayCycle(ctx context.Context) {
 			}
 
 			if err := rw.activator.SyntheticActivate(ctx, vault, queryCtx); err != nil {
+				rw.errors.Add(1)
 				slog.Debug("replay: synthetic activate failed",
 					"vault", vault,
 					"engram", fmt.Sprintf("%x", eg.ID),
 					"error", err)
 				continue
 			}
+			rw.engramsReplayed.Add(1)
 			totalActivated++
 		}
 	}

--- a/internal/cognitive/replay_metrics_test.go
+++ b/internal/cognitive/replay_metrics_test.go
@@ -1,0 +1,194 @@
+package cognitive
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// errActivator fails every SyntheticActivate call with an error.
+type errActivator struct{}
+
+func (e *errActivator) SyntheticActivate(_ context.Context, _ string, _ string) error {
+	return fmt.Errorf("synthetic activate error")
+}
+
+// partialErrActivator fails for a specific vault.
+type partialErrActivator struct {
+	mu       sync.Mutex
+	failVault string
+	calls     int
+}
+
+func (p *partialErrActivator) SyntheticActivate(_ context.Context, vault string, _ string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	if vault == p.failVault {
+		return fmt.Errorf("fail vault")
+	}
+	return nil
+}
+
+func TestReplayMetricsIncrement(t *testing.T) {
+	activator := &mockReplayActivator{}
+	store := &mockReplayStore{
+		vaults: []string{"v1", "v2"},
+		engrams: map[string][]ReplayEngram{
+			"v1": {
+				{ID: [16]byte{1}, Concept: "c1", Content: "content-1", Vault: "v1"},
+				{ID: [16]byte{2}, Concept: "c2", Content: "content-2", Vault: "v1"},
+			},
+			"v2": {
+				{ID: [16]byte{3}, Concept: "c3", Content: "content-3", Vault: "v2"},
+			},
+		},
+	}
+	cfg := ReplayConfig{
+		Interval:     20 * time.Millisecond,
+		LearningRate: 0.005,
+		MaxEngrams:   100,
+	}
+	rw := NewReplayWorker(cfg, activator, store)
+
+	// Run a single cycle directly.
+	rw.replayCycle(context.Background())
+
+	m := rw.Metrics()
+	if m.CyclesCompleted != 1 {
+		t.Errorf("CyclesCompleted = %d, want 1", m.CyclesCompleted)
+	}
+	if m.EngramsReplayed != 3 {
+		t.Errorf("EngramsReplayed = %d, want 3", m.EngramsReplayed)
+	}
+	if m.VaultsProcessed != 2 {
+		t.Errorf("VaultsProcessed = %d, want 2", m.VaultsProcessed)
+	}
+	if m.Errors != 0 {
+		t.Errorf("Errors = %d, want 0", m.Errors)
+	}
+	if m.LastCycleDuration <= 0 {
+		t.Errorf("LastCycleDuration = %v, want > 0", m.LastCycleDuration)
+	}
+	if m.LastCycleAt.IsZero() {
+		t.Error("LastCycleAt is zero, want non-zero")
+	}
+
+	// Run another cycle and verify counters accumulate.
+	rw.replayCycle(context.Background())
+	m2 := rw.Metrics()
+	if m2.CyclesCompleted != 2 {
+		t.Errorf("CyclesCompleted after 2 cycles = %d, want 2", m2.CyclesCompleted)
+	}
+	if m2.EngramsReplayed != 6 {
+		t.Errorf("EngramsReplayed after 2 cycles = %d, want 6", m2.EngramsReplayed)
+	}
+	if m2.VaultsProcessed != 4 {
+		t.Errorf("VaultsProcessed after 2 cycles = %d, want 4", m2.VaultsProcessed)
+	}
+}
+
+func TestReplayMetricsErrors(t *testing.T) {
+	activator := &errActivator{}
+	store := &mockReplayStore{
+		vaults: []string{"v1"},
+		engrams: map[string][]ReplayEngram{
+			"v1": {
+				{ID: [16]byte{1}, Concept: "c1", Content: "content-1", Vault: "v1"},
+				{ID: [16]byte{2}, Concept: "c2", Content: "content-2", Vault: "v1"},
+			},
+		},
+	}
+	cfg := ReplayConfig{
+		Interval:     20 * time.Millisecond,
+		LearningRate: 0.005,
+		MaxEngrams:   100,
+	}
+	rw := NewReplayWorker(cfg, activator, store)
+
+	rw.replayCycle(context.Background())
+
+	m := rw.Metrics()
+	if m.CyclesCompleted != 1 {
+		t.Errorf("CyclesCompleted = %d, want 1", m.CyclesCompleted)
+	}
+	if m.Errors != 2 {
+		t.Errorf("Errors = %d, want 2", m.Errors)
+	}
+	if m.EngramsReplayed != 0 {
+		t.Errorf("EngramsReplayed = %d, want 0 (all should have failed)", m.EngramsReplayed)
+	}
+	if m.VaultsProcessed != 1 {
+		t.Errorf("VaultsProcessed = %d, want 1", m.VaultsProcessed)
+	}
+}
+
+func TestReplayMetricsThreadSafety(t *testing.T) {
+	activator := &mockReplayActivator{}
+	store := &mockReplayStore{
+		vaults: []string{"v1"},
+		engrams: map[string][]ReplayEngram{
+			"v1": {
+				{ID: [16]byte{1}, Concept: "c1", Content: "content-1", Vault: "v1"},
+			},
+		},
+	}
+	cfg := ReplayConfig{
+		Interval:     10 * time.Millisecond,
+		LearningRate: 0.005,
+		MaxEngrams:   100,
+	}
+	rw := NewReplayWorker(cfg, activator, store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go rw.Run(ctx)
+
+	// Wait for at least one cycle to complete before starting concurrent reads.
+	deadline := time.After(3 * time.Second)
+	for {
+		if rw.Metrics().CyclesCompleted >= 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			cancel()
+			<-rw.Done()
+			t.Fatal("timed out waiting for first replay cycle")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	// Concurrently read metrics while cycles are still running.
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				m := rw.Metrics()
+				// Sanity: exercises concurrent reads without data races.
+				_ = m.CyclesCompleted
+				_ = m.EngramsReplayed
+				_ = m.Errors
+				_ = m.VaultsProcessed
+				_ = m.LastCycleDuration
+				_ = m.LastCycleAt
+			}
+		}()
+	}
+	wg.Wait()
+
+	cancel()
+	<-rw.Done()
+
+	// After shutdown, metrics should reflect completed cycles.
+	m := rw.Metrics()
+	if m.CyclesCompleted == 0 {
+		t.Error("expected at least 1 cycle after running worker")
+	}
+	if m.EngramsReplayed == 0 {
+		t.Error("expected at least 1 engram replayed")
+	}
+}

--- a/internal/cognitive/worker.go
+++ b/internal/cognitive/worker.go
@@ -266,10 +266,11 @@ func (w *Worker[T]) Stats() WorkerStats {
 
 // EngineWorkerStats holds the combined statistics for all cognitive workers.
 type EngineWorkerStats struct {
-	Hebbian    WorkerStats `json:"hebbian"`
-	Contradict WorkerStats `json:"contradict"`
-	Confidence WorkerStats `json:"confidence"`
-	Episode    WorkerStats `json:"episode"`
+	Hebbian    WorkerStats   `json:"hebbian"`
+	Contradict WorkerStats   `json:"contradict"`
+	Confidence WorkerStats   `json:"confidence"`
+	Episode    WorkerStats   `json:"episode"`
+	Replay     ReplayMetrics `json:"replay"`
 }
 
 // StartAll runs multiple workers via errgroup. Returns first error.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2563,6 +2563,12 @@ func (e *Engine) WorkerStats() cognitive.EngineWorkerStats {
 	if ep != nil {
 		stats.Episode = ep.Stats()
 	}
+	e.cogMu.RLock()
+	rw := e.replayWorker
+	e.cogMu.RUnlock()
+	if rw != nil {
+		stats.Replay = rw.Metrics()
+	}
 	return stats
 }
 


### PR DESCRIPTION
## Summary

Adds **replay effectiveness metrics** for Bayesian feature search integration.

### What's implemented
- **`ReplayMetrics`** — CyclesCompleted, EngramsReplayed, VaultsProcessed, LastCycleDuration, LastCycleAt, Errors
- **Thread-safe counters** via `sync/atomic` (matches existing Worker[T] pattern)
- **`Metrics()` method** — returns atomic snapshot
- **Wired into `EngineWorkerStats.Replay`** — exposed via REST `/debug/workers` endpoint
- **3 tests** — counter increment, error tracking, concurrent thread safety

### Design
- Metrics exposed through existing observability layer (EngineWorkerStats), not a new MCP tool
- Atomic operations for all counters — safe for concurrent reads during replay cycles

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)